### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
 # Twilio API credentials
 # Found at https://www.twilio.com/user/account/settings
-export TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
-export TWILIO_AUTH_TOKEN=your-token
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your-token
 
 # Twilio phone number
 # Purchase one at https://www.twilio.com/user/account/phone-numbers
-export TWILIO_NUMBER=+15551234567
+TWILIO_NUMBER=+15551234567

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: [ 2.3, 2.6 ]
+        ruby: [ 2.6 ]
 
     steps:
       - name: Checkout code
@@ -24,9 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install gems
-        run: |
-          bundle install
+          bundler-cache: true
       - name: Run tests
         run: |
           cp .env.example .env

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
+gem 'dotenv'
 gem 'sinatra'
 gem 'twilio-ruby', '>= 5.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     diff-lcs (1.2.5)
+    dotenv (2.7.6)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     jwt (1.5.6)
@@ -57,6 +58,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  dotenv
   rack-test
   rake
   rspec
@@ -64,4 +66,4 @@ DEPENDENCIES
   twilio-ruby (>= 5.0.0)
 
 BUNDLED WITH
-   1.15.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of people when an error happens in a web application.
 
 [Read the full tutorial here!](https://www.twilio.com/docs/tutorials/walkthrough/server-notifications/ruby/sinatra)
 
-## Local development
+## Get started
 
 This project is built using [Sinatra](http://www.sinatrarb.com/) Framework.
 
@@ -33,8 +33,6 @@ This project is built using [Sinatra](http://www.sinatrarb.com/) Framework.
    for the Twilio API (found at https://www.twilio.com/console/account/settings).
    You will also need a [Twilio Number](https://www.twilio.com/console/phone-numbers/incoming).
 
-   Run `source .env` to export the environment variables.
-
 1. Edit the administrators listed in the [`config/administrators.yml`](config/administrators.yml).
    Make sure to use real phone numbers otherwise the application won't work.
 
@@ -51,6 +49,14 @@ This project is built using [Sinatra](http://www.sinatrarb.com/) Framework.
    ```
 
 1. Check it out at [`http://localhost:9292`](http://localhost:9292).
+
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
 
 ## Meta
 

--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,18 @@
-require 'sinatra/base'
+require 'dotenv'
+require 'sinatra'
 require_relative './lib/notifier'
 
-ENV['RACK_ENV'] ||= 'development'
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
 
 require 'bundler'
-Bundler.require :default, ENV['RACK_ENV'].to_sym
+Bundler.require :default, environment
+
 
 module ServerNotifications
   class App < Sinatra::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 require_relative '../app'
 require 'rspec'
 require 'capybara/rspec'


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Install dotenv
- Update README.
- Update the CI script to run only on 2.6 (2.3 is deprecated) and use the cache